### PR TITLE
Debug jwt auth guard dependency error

### DIFF
--- a/backend/src/reportes-internos/reportes-internos.module.ts
+++ b/backend/src/reportes-internos/reportes-internos.module.ts
@@ -5,6 +5,8 @@ import { ReporteInterno2 } from "./entities/reporte-interno2.entity";
 import { ReporteInterno3 } from "./entities/reporte-interno3.entity";
 import { reportesInternosController } from "./reportes-internos.controller";
 import { reportesInternosService } from "./reportes-internos.service";
+import { AuthModule } from "../auth/auth.module";
+import { JwtAuthGuard } from "../auth/jwt.guard";
 
 
 @Module({
@@ -12,10 +14,11 @@ import { reportesInternosService } from "./reportes-internos.service";
         TypeOrmModule.forFeature([
             ReporteInterno1, ReporteInterno2, ReporteInterno3,
         ]),
+        AuthModule,
     ],
 
     controllers: [reportesInternosController],
-    providers: [reportesInternosService]
+    providers: [reportesInternosService, JwtAuthGuard]
 })
 
 export class ReporteInternosModule {}


### PR DESCRIPTION
Import `AuthModule` and add `JwtAuthGuard` as a provider to `ReporteInternosModule` to resolve `JwtService` dependency error.

---
<a href="https://cursor.com/background-agent?bcId=bc-3669627b-48b3-4057-8e31-54b1b9035cf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3669627b-48b3-4057-8e31-54b1b9035cf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

